### PR TITLE
Merge Resiliency into master for cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,23 @@ https://github.com/ibm-cloud-architecture/refarch-cloudnative-netflix*
 #### Introduction
 
 This project is built to demonstrate how to build a Spring Boot application for use in a microservices-based architecture:
- - Leverage Spring Boot framework to build a microservices application.
- - Integrate with [Netflix Eureka](https://github.com/Netflix/eureka) framework.
+ - Leverage Spring Boot & Spring Cloud frameworks to build a microservices-based application.
+ - Integrate with the [Netflix Eureka](https://github.com/Netflix/eureka) framework.
  - Deployment options for local, Cloud Foundry, or Docker Container-based runtimes (including [IBM Container Service](https://console.ng.bluemix.net/docs/containers/container_index.html) on [Bluemix](https://new-console.ng.bluemix.net/#overview)).
+
+Additionally, this microservice leverages robust resiliency capabilities, provided in this implementation by the Spring Cloud Config Server client libraries.  The microservice will retry multiple times to contact the Config Server for the most up-to-date configuration data upon startup.  Should the Config Server still be unavailable, after a configurable period of retries, the microservice will fail to start and can be diagnosed for additional connectivity problems or configured to be started with static built-in configuration data.  
+
+For more information on Spring Cloud Config Server retry capabilities, you can reference the [Spring Cloud Config Server](https://cloud.spring.io/spring-cloud-config/spring-cloud-config.html#config-client-retry) documentation.  Regardless of framework and tooling selection, resiliency capabilities, like this configurable retry logic, are critical in microservice-based applications.
 
 #### APIs in this application
 You can use cURL or Chrome POSTMAN to send get/post/put/delete requests to the application.
 - Get available options for Appetizers  
 `http://<hostname>/appetizers`
+
+#### Configuration Options in this application
+These options can be set on the command-line, in a Docker Compose environment file, or any other way that [Spring Boot supports](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html):  
+- Disable Config Server retry logic, allowing startup without remote configuration data:  
+  `spring.cloud.config.failFast=false`
 
 #### Pre-requisite:
 - You need a Docker machine running on localhost to host container(s). [Click for instructions](https://docs.docker.com/machine/get-started/).

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,9 @@ repositories {
 
 
 dependencies {
-	compile('org.springframework.cloud:spring-cloud-starter-config')
+    compile('org.springframework.cloud:spring-cloud-sleuth-zipkin')
+    compile('org.springframework.cloud:spring-cloud-starter-sleuth')
+    compile('org.springframework.cloud:spring-cloud-starter-config')
 	compile('org.springframework.boot:spring-boot-starter-actuator')
 	compile('org.springframework.cloud:spring-cloud-starter-eureka')
 	compile('org.springframework.boot:spring-boot-starter-web')

--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,11 @@ repositories {
 
 
 dependencies {
-    compile('org.springframework.cloud:spring-cloud-sleuth-zipkin')
-    compile('org.springframework.cloud:spring-cloud-starter-sleuth')
-    compile('org.springframework.cloud:spring-cloud-starter-config')
+	compile('org.springframework.retry:spring-retry')
+	compile('org.springframework.boot:spring-boot-starter-aop')
+	compile('org.springframework.cloud:spring-cloud-sleuth-zipkin')
+	compile('org.springframework.cloud:spring-cloud-starter-sleuth')
+	compile('org.springframework.cloud:spring-cloud-starter-config')
 	compile('org.springframework.boot:spring-boot-starter-actuator')
 	compile('org.springframework.cloud:spring-cloud-starter-eureka')
 	compile('org.springframework.boot:spring-boot-starter-web')

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,14 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-sleuth-zipkin</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-sleuth</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,14 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.springframework.retry</groupId>
+			<artifactId>spring-retry</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-aop</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-sleuth-zipkin</artifactId>
 		</dependency>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,11 @@
 spring:
   application:
     name: appetizer-service
+  sleuth:
+    sampler:
+      percentage: 1.0
+  zipkin:
+    baseUrl: ${vcap.services.zipkin-server.credentials.uri:http://localhost:9411}
 
 server:
   port: ${vcap.application.port:8082}

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -4,3 +4,12 @@ spring:
   cloud:
     config:
       uri: ${vcap.services.config-server.credentials.uri:http://localhost:8888}
+      failFast: true
+      retry:
+        initialInterval: 1500
+        multiplier: 1.5
+        maxInterval: 10000
+        maxAttempts: 10
+      discovery:
+        serviceId: config-server
+        enabled: false

--- a/src/test/java/com/ibm/microservices/wfd/appetizer/AppetizerApplicationTests.java
+++ b/src/test/java/com/ibm/microservices/wfd/appetizer/AppetizerApplicationTests.java
@@ -6,8 +6,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
+@SpringBootTest( properties = { "spring.cloud.config.enabled:false",
+																"spring.cloud.discovery.enabled:false" } )
 public class AppetizerApplicationTests {
+	
+	//Config and Discovery services are disabled for contextLoads tests
 
 	@Test
 	public void contextLoads() {


### PR DESCRIPTION
Merging resiliency branch into master, as it's a superset of all other branches. This is in an effort to clean up old branches and rebase on our newer dual support for both Spring and Microprofile going forward.